### PR TITLE
Fix handling of attributes

### DIFF
--- a/Attr.js
+++ b/Attr.js
@@ -4,18 +4,32 @@ import { htmlEscape } from './utils.js';
 export class Attr extends Node {
 	#name;
 	#value;
+	#ownerElement;
 
 	constructor(name) {
 		if (typeof name !== 'string' || ! /^[A-Za-z\d\-_]+$/.test(name)) {
 			throw new DOMException('String contains an invalid character');
 		} else {
 			super();
+			this.#ownerElement = null;
 			this.#name = name;
 		}
 	}
 
 	toString() {
 		return `${this.name}="${htmlEscape(this.#value)}"`;
+	}
+
+	get ownerElement() {
+		return this.#ownerElement;
+	}
+
+	set ownerElement(el) {
+		if (el !== null && ! (el instanceof Node && el.nodeType === Node.ELEMENT_NODE)) {
+			throw new TypeError('Not an Element');
+		} else {
+			this.#ownerElement = el;
+		}
 	}
 
 	get name() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.0.2] - 2023-10-20
 
+### Added
+- Add `Element.getAttributeNames()`
+
 ### Fixed
 - `element.attributes` now returns a `NamedNodeMap`
 - `dataset`, `classList`, `relList`, and `sandbox` now correspond to their attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.0.2] - 2023-10-20
+
+### Fixed
+- `element.attributes` now returns a `NamedNodeMap`
+- `dataset`, `classList`, `relList`, and `sandbox` now correspond to their attributes
+- `Attr`s now have `ownerElement`s
+- Can now `delete element.dataset.foo` and it will remove the `data-foo` attribute
+
 ## [v0.0.1] - 2023-10-20
 
 Initial Release

--- a/DOMTokenList.js
+++ b/DOMTokenList.js
@@ -1,8 +1,12 @@
 export class DOMTokenList {
 	#items;
+	#el;
+	#attr;
 
-	constructor() {
-		this.#items = new Set();
+	constructor(el, attr) {
+		this.#el = el;
+		this.#attr = attr;
+		this.#items = new Set(el.getAttribute(attr).trim().split(' ').filter(str => str.length !== 0));
 	}
 
 	toString() {
@@ -23,6 +27,7 @@ export class DOMTokenList {
 
 	add(...items){
 		items.forEach(item => this.#items.add(item));
+		this.#el.setAttribute(this.#attr, this.value);
 	}
 
 	contains(item){
@@ -55,5 +60,6 @@ export class DOMTokenList {
 
 	remove(...items) {
 		items.forEach(item => this.#items.delete(item));
+		this.#el.setAttribute(this.#attr, this.value);
 	}
 }

--- a/Document.js
+++ b/Document.js
@@ -1,5 +1,4 @@
 import { Node,  Text } from './Node.js';
-// import { Element } from './Element.js';
 import { HTMLUnknownElement } from './html/HTMLUnknownElement.js';
 import { DocumentFragment } from './DocumentFragment.js';
 import { HTMLCollection } from './HTMLCollection.js';

--- a/Element.js
+++ b/Element.js
@@ -156,6 +156,10 @@ export class Element extends Node {
 		}
 	}
 
+	getAttributeNames() {
+		return this.attributes.map(({ name })  => name);
+	}
+
 	getElementsByClassName(names) {
 		const classList = names.trim().split(' ').filter(str => str.length !== 0);
 

--- a/NamedNodeMap.js
+++ b/NamedNodeMap.js
@@ -1,23 +1,37 @@
 // import { Node } from './Node.js';
+import { Attr } from './Attr.js';
 
-export class NamedNodeMap {
-	#map;
-
-	constructor(entities) {
-		this.#map = new Map(entities);
+export class NamedNodeMap extends Array {
+	item(n) {
+		return this[n];
 	}
 
 	getNamedItem(name) {
-		return this.#map.get(name);
+		return this.find(attr => attr.name === name);
+	}
+
+	removeNamedItem(name) {
+		const index = this.findIndex(attr => attr.name === name);
+
+		if (index !== -1) {
+			const attr = this.item(index);
+			attr.ownerElement === null;
+			this.splice(index, 1);
+			return attr;
+		}
 	}
 
 	setNamedItem(attr) {
 		if (! (attr instanceof Attr)) {
-			throw new TypeError('Not an Attr.');
+			throw new TypeError('Not an attribute');
+		}
+
+		const index = this.findIndex(attr => attr.name === 'name');
+
+		if (index !== -1) {
+			this[index] =  attr;
 		} else {
-			const oldVal = this.#map.get(attr.name);
-			this.#map.set(attr.name, attr);
-			return oldVal;
+			this.push(attr);
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ that end up being saved or sent as strings.
 - All elements can be created using `new SomeElement()`
 - All elements return their `outerHTML` via `toString()`
 - `Document` has additional static `createElement()` & `registerElement()` methods
+- `Attr.ownerElement` is not read-only
 - There is no global `document` unless you create it (`globalThis.document = new HTMLDocument()`)
 - The element classes are not attached to the global object either (e.g. no `HTMLScriptElement`)
 - Some property getters associated with attributes may return the wrong types when not set (e.g. `''` instead of `null` or `undefined`)
@@ -157,9 +158,7 @@ that end up being saved or sent as strings.
 - Doctype will always be `<!DOCTYPE html>`
 - `elememt.after()`, `element.before()`, `node.insertBefore()`, `node.insertAfter()`
 - `node.cloneNode()`, `node.isSameNode()`, `node.isEqualNode()`
-- `Element.attributes` returns an array instead of a `NamedNodeMap`
-- `relList`, `classList`, `part`, `dataset` are stored separately from other attributes and cannot be accessed through `getAttribute()` & `setAttribute()`
-- `element.style` not supported except as `element.setAttribute('style', style)`
+- `element.style` not supported except as `element.setAttribute('style', styleString)`
 -  [`aria*`](https://developer.mozilla.org/en-US/docs/Web/API/Element#instance_properties_included_from_aria) properties
 - Tables and many form/input properties and methods
 - Various properties, methods, and classes

--- a/html/HTMLAnchorElement.js
+++ b/html/HTMLAnchorElement.js
@@ -3,11 +3,8 @@ import { Document } from '../Document.js';
 import { DOMTokenList } from '../DOMTokenList.js';
 
 export const HTMLAnchorElement = Document.registerElement('a', class HTMLAnchorElement extends HTMLElement {
-	#relList;
-
 	constructor() {
 		super();
-		this.#relList = new DOMTokenList();
 	}
 
 	get download() {
@@ -33,16 +30,15 @@ export const HTMLAnchorElement = Document.registerElement('a', class HTMLAnchorE
 	}
 
 	get rel() {
-		return this.#relList.value;
+		return this.getAttribute('rel');
 	}
 
 	set rel(val) {
-		this.#relList.remove(...this.#relList.values());
-		this.#relList.add(...val.split(' '));
+		this.setAttribute('rel', val);
 	}
 
 	get relList() {
-		return this.#relList;
+		return new DOMTokenList(this, 'rel');
 	}
 
 	get tagName() {

--- a/html/HTMLIFrameElement.js
+++ b/html/HTMLIFrameElement.js
@@ -3,11 +3,8 @@ import { Document } from '../Document.js';
 import { DOMTokenList } from '../DOMTokenList.js';
 
 export const HTMLIFrameElement = Document.registerElement('iframe', class HTMLIFrameElement extends HTMLElement {
-	#sandbox;
-
 	constructor() {
 		super();
-		this.#sandbox = new DOMTokenList();
 	}
 
 	get allow() {
@@ -51,7 +48,7 @@ export const HTMLIFrameElement = Document.registerElement('iframe', class HTMLIF
 	}
 
 	get sandbox() {
-		return this.#sandbox;
+		return new DOMTokenList(this, 'sandbox');
 	}
 
 	get src() {

--- a/html/HTMLLinkElement.js
+++ b/html/HTMLLinkElement.js
@@ -3,11 +3,8 @@ import { Document } from '../Document.js';
 import { DOMTokenList } from '../DOMTokenList.js';
 
 export const HTMLLinkElement = Document.registerElement('link', class HTMLLinkElement extends HTMLElement {
-	#relList;
-
 	constructor() {
 		super();
-		this.#relList = new DOMTokenList();
 	}
 
 	get href() {
@@ -27,16 +24,15 @@ export const HTMLLinkElement = Document.registerElement('link', class HTMLLinkEl
 	}
 
 	get rel() {
-		return this.#relList.value;
+		return this.getAttribute('rel');
 	}
 
 	set rel(val) {
-		this.#relList.remove(...this.#relList.values());
-		this.#relList.add(...val.split(' '));
+		this.setAttribute('rel', val);
 	}
 
 	get relList() {
-		return this.#relList;
+		return new DOMTokenList(this, 'rel');
 	}
 
 	get tagName() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/node-dom",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/node-dom",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shgysk8zer0/node-dom",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A template repo for npm packages",
   "keywords": [
     "html",

--- a/test.js
+++ b/test.js
@@ -47,6 +47,8 @@ a.relList.add('noreferrer', 'noopener');
 a.target = '_blank';
 a.append(img);
 
+console.log(a.getAttribute('rel'));
+
 div.classList.add('container');
 div.append(a);
 
@@ -57,6 +59,8 @@ link.media = 'all';
 iframe.src = 'https://events.kernvalley.us/embed/';
 iframe.sandbox.add('allow-script');
 iframe.part.add('content');
+iframe.hidden = true;
+iframe.attributes.removeNamedItem('hidden');
 
 document.head.append(base, link, script);
 


### PR DESCRIPTION
- `element.attributes` now returns a `NamedNodeMap`
- `dataset`, `classList`, `relList`, and `sandbox` now correspond to
their attributes
- `Attr`s now have `ownerElement`s
- Can now `delete element.dataset.foo` and it will remove the `data-foo`
attribute

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
